### PR TITLE
Removed command to run performance experiments along build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,8 @@ docker run -i -t prospect
 Building the Docker container takes about 2 hours and requires 7 GB of disk space.
 
 By default, the build process only runs the security tests.
-The performance benchmarks can also be run already during the build by specifying the `BENCHMARKS=true` build argument (this will add 9+ hours to the build process):
-
-```shell
-docker build -t prospect --build-arg BENCHMARKS=true .
-```
+The performance benchmarks can also be run already during the build by specifying the `BENCHMARKS=true` build argument (this will add 9+ hours to the build process).
+This step is optional and the performance benchmarks can still be run later.
 
 ### Security tests
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker run -i -t prospect
 Building the Docker container takes about 2 hours and requires 7 GB of disk space.
 
 By default, the build process only runs the security tests.
-The performance benchmarks can also be run already during the build by specifying the `BENCHMARKS=true` build argument (this will add 9+ hours to the build process).
+The performance benchmarks can also be run already during the build by adding `--build-arg BENCHMARKS=true` to the build command (this will add 9+ hours to the build process).
 This step is optional and the performance benchmarks can still be run later.
 
 ### Security tests


### PR DESCRIPTION
I imagine that some people will not read carefully and just run the commands one after the other. In that case, we probably don't want them to run this one yet, so I removed it.

If a user really wants to run the performance experiments already, they can easily come up with the command themselves.